### PR TITLE
Store fully processed old vdom between renders for faster re-renders

### DIFF
--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -140,14 +140,18 @@
       (seq classes) (assoc :classes classes)
       (string? (:style attrs)) (update :style explode-styles))))
 
+(defn ^:private flatten-seqs* [xs coll]
+  (reduce
+   (fn [_ x]
+     (cond (nil? x) nil
+           (seq? x) (flatten-seqs* x coll)
+           :else (conj! coll x)))
+   nil xs))
+
 (defn flatten-seqs [xs]
-  (persistent!
-   (reduce (fn [res x]
-             (cond (nil? x) res
-                   (seq? x) (reduce conj! res (flatten-seqs x))
-                   :else (conj! res x))) (transient []) xs)))
-
-
+  (let [coll (transient [])]
+    (flatten-seqs* xs coll)
+    (persistent! coll)))
 
 (defn get-children
   "Given an optional tag namespace `ns` (e.g. for SVG nodes) and `headers`, as

--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -438,7 +438,10 @@
           ;; original position of the two nodes currently being considered, to
           ;; determine which it is.
           :else
-          (let [o-idx (int (index-of #(reusable? new-headers %) old-c))]
+          (let [o-idx (if (and (not (string? new-headers))
+                               (nth new-headers hiccup-key))
+                        (int (index-of #(reusable? new-headers %) old-c))
+                        -1)]
             (if (< o-idx 0)
               ;; new-hiccup represents a node that did not previously exist,
               ;; create it
@@ -447,7 +450,10 @@
                   (r/append-child r el child)
                   (r/insert-before r el child (r/get-child r el n)))
                 (recur (next new-c) old-c (unchecked-inc-int n) move-n (unchecked-inc-int n-children) true (conj! vdom child-vdom)))
-              (let [n-idx (int (index-of #(reusable? % old-vdom) new-c))]
+              (let [n-idx (if (and (not (string? old-vdom))
+                                   (:key (nth old-vdom vdom-attrs)))
+                            (int (index-of #(reusable? % old-vdom) new-c))
+                            -1)]
                 (cond
                   ;; the old node no longer exists, remove it
                   (< n-idx 0)

--- a/src/replicant/dom.cljs
+++ b/src/replicant/dom.cljs
@@ -85,14 +85,14 @@
     (get-child [_this el idx]
       (aget (.-childNodes el) idx))))
 
-(defonce state (atom {}))
+(defonce state (volatile! {}))
 
 (defn ^:export render [el hiccup]
   (when-not (contains? @state el)
-    (swap! state assoc el {:renderer (create-renderer)}))
-  (let [{:keys [renderer current]} (get @state el)]
-    (r/reconcile renderer el hiccup current))
-  (swap! state assoc-in [el :current] hiccup)
+    (vswap! state assoc el {:renderer (create-renderer)}))
+  (let [{:keys [renderer current]} (get @state el)
+        {:keys [vdom]} (r/reconcile renderer el hiccup current)]
+    (vswap! state assoc-in [el :current] vdom))
   el)
 
 (defn ^:export set-dispatch! [f]

--- a/src/replicant/hiccup.clj
+++ b/src/replicant/hiccup.clj
@@ -9,7 +9,7 @@
 (defmacro class [headers]
   `(nth ~headers 2))
 
-(defmacro key [headers]
+(defmacro rkey [headers]
   `(nth ~headers 3))
 
 (defmacro attrs [headers]
@@ -18,7 +18,7 @@
 (defmacro children [headers]
   `(nth ~headers 5))
 
-(defmacro namespace [headers]
+(defmacro html-ns [headers]
   `(nth ~headers 6))
 
 (defmacro sexp [headers]

--- a/src/replicant/hiccup.clj
+++ b/src/replicant/hiccup.clj
@@ -1,0 +1,25 @@
+(ns replicant.hiccup)
+
+(defmacro tag-name [headers]
+  `(nth ~headers 0))
+
+(defmacro id [headers]
+  `(nth ~headers 1))
+
+(defmacro class [headers]
+  `(nth ~headers 2))
+
+(defmacro key [headers]
+  `(nth ~headers 3))
+
+(defmacro attrs [headers]
+  `(nth ~headers 4))
+
+(defmacro children [headers]
+  `(nth ~headers 5))
+
+(defmacro namespace [headers]
+  `(nth ~headers 6))
+
+(defmacro sexp [headers]
+  `(nth ~headers 7))

--- a/src/replicant/hiccup.cljs
+++ b/src/replicant/hiccup.cljs
@@ -1,0 +1,2 @@
+(ns replicant.hiccup
+  (:require-macros [replicant.hiccup]))

--- a/src/replicant/mutation_log.cljc
+++ b/src/replicant/mutation_log.cljc
@@ -125,14 +125,15 @@
      :element (or element (atom {}))}
     mutation-log-impl))
 
-(defn render [element new-hiccup & [old-hiccup]]
+(defn render [element new-hiccup & [old-vdom]]
   (let [el (atom (or element {}))
         renderer (create-renderer {:log (atom []) :element el})
-        hooks (d/reconcile renderer el new-hiccup old-hiccup)]
+        {:keys [hooks vdom]} (d/reconcile renderer el new-hiccup old-vdom)]
     {:el (-> renderer
              (update :log deref)
              (update :element deref))
-     :hooks hooks}))
+     :hooks hooks
+     :vdom vdom}))
 
 (comment
   (do

--- a/src/replicant/vdom.clj
+++ b/src/replicant/vdom.clj
@@ -1,0 +1,13 @@
+(ns replicant.vdom)
+
+(defmacro tag-name [vdom]
+  `(nth ~vdom 0))
+
+(defmacro attrs [vdom]
+  `(nth ~vdom 1))
+
+(defmacro children [vdom]
+  `(nth ~vdom 2))
+
+(defmacro sexp [vdom]
+  `(nth ~vdom 3))

--- a/src/replicant/vdom.clj
+++ b/src/replicant/vdom.clj
@@ -9,5 +9,11 @@
 (defmacro children [vdom]
   `(nth ~vdom 2))
 
-(defmacro sexp [vdom]
+(defmacro child-ks [vdom]
   `(nth ~vdom 3))
+
+(defmacro sexp [vdom]
+  `(nth ~vdom 4))
+
+(defmacro create [tag-name attrs children child-ks sexp]
+  `[~tag-name ~attrs ~children ~child-ks ~sexp])

--- a/src/replicant/vdom.cljs
+++ b/src/replicant/vdom.cljs
@@ -1,0 +1,2 @@
+(ns replicant.vdom
+  (:require-macros [replicant.vdom]))

--- a/test/replicant/core_test.clj
+++ b/test/replicant/core_test.clj
@@ -7,7 +7,7 @@
 (deftest hiccup-test
   (testing "Normalizes hiccup structure"
     (is (= (sut/get-hiccup-headers [:h1 "Hello world"] nil)
-           ["h1" nil nil nil {} ["Hello world"] nil])))
+           ["h1" nil nil nil {} ["Hello world"] nil [:h1 "Hello world"]])))
 
   (testing "Flattens children"
     (is (= (-> (sut/get-hiccup-headers [:h1 (list (list "Hello world"))] nil)

--- a/test/replicant/core_test.clj
+++ b/test/replicant/core_test.clj
@@ -132,7 +132,7 @@
 
   (testing "Builds svg nodes"
     (is (= (-> (h/render [:svg {:viewBox "0 0 100 100"}
-                        [:g [:use {:xlink:href "#icon"}]]])
+                          [:g [:use {:xlink:href "#icon"}]]])
                h/get-mutation-log-events
                h/summarize)
            [[:create-element "svg" "http://www.w3.org/2000/svg"]
@@ -147,9 +147,9 @@
   (testing "Properly adds svg to existing nodes"
     (is (= (-> (h/render [:div [:h1 "Hello"]])
                (h/render [:div
-                        [:h1 "Hello"]
-                        [:svg {:viewBox "0 0 100 100"}
-                         [:g [:use {:xlink:href "#icon"}]]]])
+                          [:h1 "Hello"]
+                          [:svg {:viewBox "0 0 100 100"}
+                           [:g [:use {:xlink:href "#icon"}]]]])
                h/get-mutation-log-events
                h/summarize)
            [[:create-element "svg" "http://www.w3.org/2000/svg"]
@@ -163,10 +163,10 @@
 
   (testing "Properly namespaces new svg children"
     (is (= (-> (h/render [:svg {:viewBox "0 0 100 100"}
-                        [:g [:use {:xlink:href "#icon"}]]])
+                          [:g [:use {:xlink:href "#icon"}]]])
                (h/render [:svg {:viewBox "0 0 100 100"}
-                        [:g [:use {:xlink:href "#icon"}]]
-                        [:g]])
+                          [:g [:use {:xlink:href "#icon"}]]
+                          [:g]])
                h/get-mutation-log-events
                h/summarize
                first)
@@ -174,74 +174,74 @@
 
   (testing "Moves existing nodes"
     (is (= (-> (h/render [:div
-                        [:h1 {} "Title"]
-                        [:p "Paragraph 1"]
-                        [:ul [:li "List"]]])
+                          [:h1 {} "Title"]
+                          [:p "Paragraph 1"]
+                          [:ul [:li "List"]]])
                (h/render [:div
-                        [:ul [:li "List"]]
-                        [:h1 {} "Title"]
-                        [:p "Paragraph 1"]])
+                          [:ul [:li "List"]]
+                          [:h1 {} "Title"]
+                          [:p "Paragraph 1"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:ul "List"] [:h1 "Title"] :in "div"]])))
 
   (testing "Does not move initial nodes in the desired position"
     (is (= (-> (h/render [:div
-                        [:h1 "Item #1"]
-                        [:h2 "Item #2"]
-                        [:h3 "Item #3"]
-                        [:h4 "Item #4"]
-                        [:h5 "Item #5"]])
+                          [:h1 "Item #1"]
+                          [:h2 "Item #2"]
+                          [:h3 "Item #3"]
+                          [:h4 "Item #4"]
+                          [:h5 "Item #5"]])
                (h/render [:div
-                        [:h1 "Item #1"]
-                        [:h2 "Item #2"]
-                        [:h5 "Item #5"]
-                        [:h3 "Item #3"]
-                        [:h4 "Item #4"]])
+                          [:h1 "Item #1"]
+                          [:h2 "Item #2"]
+                          [:h5 "Item #5"]
+                          [:h3 "Item #3"]
+                          [:h4 "Item #4"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:h5 "Item #5"] [:h3 "Item #3"] :in "div"]])))
 
   (testing "Moves keyed nodes"
     (is (= (-> (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "2"} "Item #3"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "2"} "Item #3"]])
                (h/render [:ul
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]])
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:li "Item #3"] [:li "Item #1"] :in "ul"]])))
 
   (testing "Only moves \"disorganized\" nodes in the middle"
     (is (= (-> (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "3"} "Item #4"]
-                        [:li {:key "4"} "Item #5"]
-                        [:li {:key "5"} "Item #6"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "3"} "Item #4"]
+                          [:li {:key "4"} "Item #5"]
+                          [:li {:key "5"} "Item #6"]])
                (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "3"} "Item #4"]
-                        [:li {:key "4"} "Item #5"]
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "5"} "Item #6"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "3"} "Item #4"]
+                          [:li {:key "4"} "Item #5"]
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "5"} "Item #6"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:li "Item #3"] [:li "Item #6"] :in "ul"]])))
 
   (testing "Moves nodes beyond end of original children"
     (is (= (-> (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]])
                (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "1"} "Item #2"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "1"} "Item #2"]])
                h/get-mutation-log-events
                h/summarize)
            [[:create-element "li"]
@@ -251,20 +251,20 @@
 
   (testing "Does not re-add child nodes that did not move"
     (is (= (-> (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "3"} "Item #4"]
-                        [:li {:key "4"} "Item #5"]
-                        [:li {:key "5"} "Item #6"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "3"} "Item #4"]
+                          [:li {:key "4"} "Item #5"]
+                          [:li {:key "5"} "Item #6"]])
                (h/render [:ul
-                        [:li {:key "0"} "Item #1"] ;; Same pos
-                        [:li {:key "4"} "Item #5"]
-                        [:li {:key "2"} "Item #3"] ;; Same pos
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "3"} "Item #4"]
-                        [:li {:key "5"} "Item #6"] ;; Same pos
-                        ])
+                          [:li {:key "0"} "Item #1"] ;; Same pos
+                          [:li {:key "4"} "Item #5"]
+                          [:li {:key "2"} "Item #3"] ;; Same pos
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "3"} "Item #4"]
+                          [:li {:key "5"} "Item #6"] ;; Same pos
+                          ])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:li "Item #5"] [:li "Item #2"] :in "ul"]
@@ -272,28 +272,28 @@
 
   (testing "Swaps adjacent nodes"
     (is (= (-> (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "3"} "Item #4"]
-                        [:li {:key "4"} "Item #5"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "3"} "Item #4"]
+                          [:li {:key "4"} "Item #5"]])
                (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "3"} "Item #4"]
-                        [:li {:key "4"} "Item #5"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "3"} "Item #4"]
+                          [:li {:key "4"} "Item #5"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:li "Item #3"] [:li "Item #2"] :in "ul"]])))
 
   (testing "Swaps nodes and adjusts attributes"
     (is (= (-> (h/render [:ul
-                        [:li {:key "0" :title "Numero uno"} "Item #1"]
-                        [:li {:key "1" :title "Numero dos"} "Item #2"]])
+                          [:li {:key "0" :title "Numero uno"} "Item #1"]
+                          [:li {:key "1" :title "Numero dos"} "Item #2"]])
                (h/render [:ul
-                        [:li {:key "1" :title "Number two"} "Item #2"]
-                        [:li {:key "0" :title "Number one"} "Item #1"]])
+                          [:li {:key "1" :title "Number two"} "Item #2"]
+                          [:li {:key "0" :title "Number one"} "Item #1"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:li "Item #2"] [:li "Item #1"] :in "ul"]
@@ -302,19 +302,19 @@
 
   (testing "Surgically swaps nodes"
     (is (= (-> (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "3"} "Item #4"]
-                        [:li {:key "4"} "Item #5"]
-                        [:li {:key "5"} "Item #6"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "3"} "Item #4"]
+                          [:li {:key "4"} "Item #5"]
+                          [:li {:key "5"} "Item #6"]])
                (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "4"} "Item #5"]
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "3"} "Item #4"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "5"} "Item #6"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "4"} "Item #5"]
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "3"} "Item #4"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "5"} "Item #6"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:li "Item #5"] [:li "Item #2"] :in "ul"]
@@ -322,13 +322,13 @@
 
   (testing "Surgically swaps nodes at the end"
     (is (= (-> (h/render [:ul
-                        [:li {:key "0"} "Item #1"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "2"} "Item #3"]])
+                          [:li {:key "0"} "Item #1"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "2"} "Item #3"]])
                (h/render [:ul
-                        [:li {:key "2"} "Item #3"]
-                        [:li {:key "1"} "Item #2"]
-                        [:li {:key "0"} "Item #1"]])
+                          [:li {:key "2"} "Item #3"]
+                          [:li {:key "1"} "Item #2"]
+                          [:li {:key "0"} "Item #1"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:li "Item #3"] [:li "Item #1"] :in "ul"]
@@ -336,13 +336,13 @@
 
   (testing "Replaces text content when elements are not keyed"
     (is (= (-> (h/render [:ul
-                        [:li "Item #1"]
-                        [:li "Item #2"]
-                        [:li "Item #3"]])
+                          [:li "Item #1"]
+                          [:li "Item #2"]
+                          [:li "Item #3"]])
                (h/render [:ul
-                        [:li "Item #1"]
-                        [:li "Item #3"]
-                        [:li "Item #2"]])
+                          [:li "Item #1"]
+                          [:li "Item #3"]
+                          [:li "Item #2"]])
                h/get-mutation-log-events
                h/summarize)
            [[:create-text-node "Item #3"]
@@ -352,12 +352,12 @@
 
   (testing "Moves and removes nodes"
     (is (= (-> (h/render [:ul
-                        [:li {:key 1} "Item #1"]
-                        [:li {:key 2} "Item #2"]
-                        [:li {:key 3} "Item #3"]])
+                          [:li {:key 1} "Item #1"]
+                          [:li {:key 2} "Item #2"]
+                          [:li {:key 3} "Item #3"]])
                (h/render [:ul
-                        [:li {:key 2} "Item #2"]
-                        [:li {:key 1} "Item #1"]])
+                          [:li {:key 2} "Item #2"]
+                          [:li {:key 1} "Item #1"]])
                h/get-mutation-log-events
                h/summarize)
            [[:insert-before [:li "Item #2"] [:li "Item #1"] :in "ul"]
@@ -365,9 +365,9 @@
 
   (testing "Clears out child nodes"
     (is (= (-> (h/render [:ul
-                        [:li {:key 1} "Item #1"]
-                        [:li {:key 2} "Item #2"]
-                        [:li {:key 3} "Item #3"]])
+                          [:li {:key 1} "Item #1"]
+                          [:li {:key 2} "Item #2"]
+                          [:li {:key 3} "Item #3"]])
                (h/render [:ul])
                h/get-mutation-log-events
                h/summarize)
@@ -377,26 +377,26 @@
 
   (testing "Deletes single child node"
     (is (= (-> (h/render [:ul
-                        [:li {:key 1} "Item #1"]
-                        [:li {:key 2} "Item #2"]
-                        [:li {:key 3} "Item #3"]])
+                          [:li {:key 1} "Item #1"]
+                          [:li {:key 2} "Item #2"]
+                          [:li {:key 3} "Item #3"]])
                (h/render [:ul
-                        [:li {:key 2} "Item #2"]
-                        [:li {:key 3} "Item #3"]])
+                          [:li {:key 2} "Item #2"]
+                          [:li {:key 3} "Item #3"]])
                h/get-mutation-log-events
                h/summarize)
            [[:remove-child [:li "Item #1"] :from "ul"]])))
 
   (testing "Adds node in the middle of existing nodes"
     (is (= (-> (h/render [:div
-                        [:h1 {} "Title"]
-                        [:p {:key :p1} "Paragraph 1"]
-                        [:p {:key :p2} "Paragraph 2"]])
+                          [:h1 {} "Title"]
+                          [:p {:key :p1} "Paragraph 1"]
+                          [:p {:key :p2} "Paragraph 2"]])
                (h/render [:div
-                        [:h1 {} "Title"]
-                        [:p {:key :p0} "Paragraph 0"]
-                        [:p {:key :p1} "Paragraph 1"]
-                        [:p {:key :p2} "Paragraph 2"]])
+                          [:h1 {} "Title"]
+                          [:p {:key :p0} "Paragraph 0"]
+                          [:p {:key :p1} "Paragraph 1"]
+                          [:p {:key :p2} "Paragraph 2"]])
                h/get-mutation-log-events
                h/summarize)
            [[:create-element "p"]
@@ -406,13 +406,13 @@
 
   (testing "Adds more nodes than there previously were children"
     (is (= (-> (h/render [:div
-                        [:h1 {} "Title"]
-                        [:p {:key :p2} "Paragraph 2"]])
+                          [:h1 {} "Title"]
+                          [:p {:key :p2} "Paragraph 2"]])
                (h/render [:div
-                        [:h1 {} "Title"]
-                        [:p {:key :p0} "Paragraph 0"]
-                        [:p {:key :p1} "Paragraph 1"]
-                        [:p {:key :p2} "Paragraph 2"]])
+                          [:h1 {} "Title"]
+                          [:p {:key :p0} "Paragraph 0"]
+                          [:p {:key :p1} "Paragraph 1"]
+                          [:p {:key :p2} "Paragraph 2"]])
                h/get-mutation-log-events
                h/summarize)
            [[:create-element "p"]
@@ -426,14 +426,14 @@
 
   (testing "Adds node at the end of existing nodes"
     (is (= (-> (h/render [:div
-                        [:h1 {} "Title"]
-                        [:p {:key :p1} "Paragraph 1"]
-                        [:p {:key :p2} "Paragraph 2"]])
+                          [:h1 {} "Title"]
+                          [:p {:key :p1} "Paragraph 1"]
+                          [:p {:key :p2} "Paragraph 2"]])
                (h/render [:div
-                        [:h1 {} "Title"]
-                        [:p {:key :p1} "Paragraph 1"]
-                        [:p {:key :p2} "Paragraph 2"]
-                        [:p {:key :p0} "Paragraph 3"]])
+                          [:h1 {} "Title"]
+                          [:p {:key :p1} "Paragraph 1"]
+                          [:p {:key :p2} "Paragraph 2"]
+                          [:p {:key :p0} "Paragraph 3"]])
                h/get-mutation-log-events
                h/summarize)
            [[:create-element "p"]
@@ -567,7 +567,7 @@
                  f (fn [e] (swap! res conj e))]
              (-> (h/render [:h1 {:replicant/on-update f} "Hi!"])
                  (h/render [:h1 {:title "Heading"
-                               :replicant/on-update f} "Hi!"]))
+                                 :replicant/on-update f} "Hi!"]))
              (h/summarize-events @res))
            [[:replicant/mount "h1"]
             [:replicant/update [:replicant/updated-attrs] "h1"]])))
@@ -576,7 +576,7 @@
     (is (= (let [res (atom [])
                  f (fn [e] (swap! res conj e))]
              (-> (h/render [:h1 {:title "Heading"
-                               :replicant/on-update f} "Hi!"])
+                                 :replicant/on-update f} "Hi!"])
                  (h/render nil))
              (map :replicant/life-cycle @res))
            [:replicant/mount
@@ -595,8 +595,8 @@
                  f (fn [e] (swap! res conj e))]
              (-> (h/render [:div [:h1 "Hi!"]])
                  (h/render [:div
-                          [:h1 "Hi!"]
-                          [:p {:replicant/on-update f} "New paragraph!"]]))
+                            [:h1 "Hi!"]
+                            [:p {:replicant/on-update f} "New paragraph!"]]))
              (map :replicant/life-cycle @res))
            [:replicant/mount])))
 
@@ -605,8 +605,8 @@
                  f (fn [e] (swap! res conj e))]
              (-> (h/render [:div [:h1 "Hi!"]])
                  (h/render [:div {:replicant/on-update f}
-                          [:h1 "Hi!"]
-                          [:p {:replicant/on-update f} "New paragraph!"]]))
+                            [:h1 "Hi!"]
+                            [:p {:replicant/on-update f} "New paragraph!"]]))
              (h/summarize-events @res))
            [[:replicant/mount "p"]
             [:replicant/update [:replicant/updated-attrs
@@ -617,11 +617,11 @@
                  f (fn [e] (swap! res conj e))]
              (-> (h/render [:div {:replicant/on-update f} [:h1 "Hi!"]])
                  (h/render [:div {:lang "en"
-                                :replicant/on-update f} [:h1 "Hi!"]])
+                                  :replicant/on-update f} [:h1 "Hi!"]])
                  (h/render [:div {:lang "en"
-                                :replicant/on-update f}
-                          [:h1 "Hi!"]
-                          [:p {:replicant/on-update f} "New paragraph!"]]))
+                                  :replicant/on-update f}
+                            [:h1 "Hi!"]
+                            [:p {:replicant/on-update f} "New paragraph!"]]))
              (h/summarize-events @res))
            [[:replicant/mount "div"]
             [:replicant/update [:replicant/updated-attrs] "div"]
@@ -639,17 +639,17 @@
     (is (= (let [res (atom [])
                  f (fn [e] (swap! res conj e))]
              (-> (h/render [:div
-                          [:h1 {:replicant/on-update f} "One"]
-                          [:p.p1 {:key :p1 :replicant/on-update f} "Two"]
-                          [:p.p2 {:key :p2 :replicant/on-update f} "Three"]
-                          [:p.p3 {:key :p3 :replicant/on-update f} "Four"]
-                          [:p.p4 {:key :p4 :replicant/on-update f} "Five"]])
+                            [:h1 {:replicant/on-update f} "One"]
+                            [:p.p1 {:key :p1 :replicant/on-update f} "Two"]
+                            [:p.p2 {:key :p2 :replicant/on-update f} "Three"]
+                            [:p.p3 {:key :p3 :replicant/on-update f} "Four"]
+                            [:p.p4 {:key :p4 :replicant/on-update f} "Five"]])
                  (h/render [:div
-                          [:h1 {:replicant/on-update f} "One"]
-                          [:p.p2 {:key :p2 :replicant/on-update f} "Three"]
-                          [:p.p3 {:key :p3 :replicant/on-update f} "Four"]
-                          [:p.p1 {:key :p1 :replicant/on-update f} "Two"]
-                          [:p.p4 {:key :p4 :replicant/on-update f} "Five"]]))
+                            [:h1 {:replicant/on-update f} "One"]
+                            [:p.p2 {:key :p2 :replicant/on-update f} "Three"]
+                            [:p.p3 {:key :p3 :replicant/on-update f} "Four"]
+                            [:p.p1 {:key :p1 :replicant/on-update f} "Two"]
+                            [:p.p4 {:key :p4 :replicant/on-update f} "Five"]]))
              (h/summarize-events @res))
            [[:replicant/mount "h1"]
             [:replicant/mount "p.p1"]
@@ -664,11 +664,11 @@
     (is (= (let [res (atom [])
                  f (fn [e] (swap! res conj e))]
              (-> (h/render [:div
-                          [:h1 {:replicant/on-update f} "One"]
-                          [:p {:replicant/on-update f} "Two"]])
+                            [:h1 {:replicant/on-update f} "One"]
+                            [:p {:replicant/on-update f} "Two"]])
                  (h/render [:div
-                          [:p {:replicant/on-update f} "Two"]
-                          [:h1 {:replicant/on-update f} "One"]]))
+                            [:p {:replicant/on-update f} "Two"]
+                            [:h1 {:replicant/on-update f} "One"]]))
              (h/summarize-events @res))
            [[:replicant/mount "h1"]
             [:replicant/mount "p"]
@@ -679,25 +679,25 @@
     (is (= (let [res (atom [])
                  f (fn [e] (swap! res conj e))]
              (-> (h/render [:div.mmm-container.mmm-section
-                          [:div.mmm-media.mmm-media-at
-                           [:article.mmm-vert-layout-spread
-                            [:div
-                             [:h1.mmm-h1 {:replicant/on-update f} "Banana"]
-                             [:p.mmm-p "03.456"]]
-                            [:div.mmm-vert-layout-s.mmm-mtm
-                             [:h2.mmm-p.mmm-desktop "Energy in 100 g"]
-                             [:h2.mmm-p.mmm-mobile.mmm-mbs "Energy"]
-                             [:p.mmm-h3.mmm-mbs.mmm-desktop "455 kJ"]]]]])
+                            [:div.mmm-media.mmm-media-at
+                             [:article.mmm-vert-layout-spread
+                              [:div
+                               [:h1.mmm-h1 {:replicant/on-update f} "Banana"]
+                               [:p.mmm-p "03.456"]]
+                              [:div.mmm-vert-layout-s.mmm-mtm
+                               [:h2.mmm-p.mmm-desktop "Energy in 100 g"]
+                               [:h2.mmm-p.mmm-mobile.mmm-mbs "Energy"]
+                               [:p.mmm-h3.mmm-mbs.mmm-desktop "455 kJ"]]]]])
                  (h/render [:div.mmm-container.mmm-section
-                          [:div.mmm-media.mmm-media-at
-                           [:article.mmm-vert-layout-spread
-                            [:div
-                             [:h1.mmm-h1 {:replicant/on-update f} "Banana!"]
-                             [:p.mmm-p "03.456"]]
-                            [:div.mmm-vert-layout-s.mmm-mtm
-                             [:h2.mmm-p.mmm-desktop "Energy in 100 g"]
-                             [:h2.mmm-p.mmm-mobile.mmm-mbs "Energy"]
-                             [:p.mmm-h3.mmm-mbs.mmm-desktop "455 kJ"]]]]]))
+                            [:div.mmm-media.mmm-media-at
+                             [:article.mmm-vert-layout-spread
+                              [:div
+                               [:h1.mmm-h1 {:replicant/on-update f} "Banana!"]
+                               [:p.mmm-p "03.456"]]
+                              [:div.mmm-vert-layout-s.mmm-mtm
+                               [:h2.mmm-p.mmm-desktop "Energy in 100 g"]
+                               [:h2.mmm-p.mmm-mobile.mmm-mbs "Energy"]
+                               [:p.mmm-h3.mmm-mbs.mmm-desktop "455 kJ"]]]]]))
              (h/summarize-events @res))
            [[:replicant/mount "h1.mmm-h1"]
             [:replicant/update [:replicant/updated-children] "h1.mmm-h1"]]))))

--- a/test/replicant/test_helper.cljc
+++ b/test/replicant/test_helper.cljc
@@ -71,9 +71,9 @@
       event)))
 
 (defn render
-  ([vdom] (assoc (mutation-log/render nil vdom) :current vdom))
-  ([{:keys [current el]} vdom]
-   (assoc (mutation-log/render (:element el) vdom current) :current vdom)))
+  ([vdom] (mutation-log/render nil vdom))
+  ([{:keys [vdom el]} new-vdom]
+   (mutation-log/render (:element el) new-vdom vdom)))
 
 (defn text-node-event? [event]
   (or (= :create-text-node (first event))


### PR DESCRIPTION
This PR trades some memory for re-rendering speed, by storing the fully realized "vdom", along with the original hiccup (e.g. everything is basically kept twice). This can be used to great effect during rendering, as Replicant can know whether a mismatching node has moved, was deleted, or is new without performing any searches through potentially big collections.

This brings all of Replicant's benchmarks into an acceptable range, while pushing memory usage a little high for some cases. I'm not 100% convinced this is the best approach, but will try to polish it from here.