### PR TITLE
FIX: Macro inclusion in cljs and type warnings

### DIFF
--- a/src/replicant/assert.cljc
+++ b/src/replicant/assert.cljc
@@ -2,7 +2,8 @@
   (:require [cljs.env :as env]
             [replicant.console-logger :as console]
             [replicant.hiccup :as hiccup])
-  (:refer-clojure :exclude [assert]))
+  (:refer-clojure :exclude [assert])
+  #?(:cljs (:require-macros [replicant.assert])))
 
 (def current-context (atom nil))
 (def current-node (atom nil))

--- a/src/replicant/asserts.cljc
+++ b/src/replicant/asserts.cljc
@@ -1,7 +1,8 @@
 (ns replicant.asserts
   (:require [replicant.assert :as assert]
             [replicant.hiccup :as hiccup]
-            [clojure.string :as str]))
+            [clojure.string :as str])
+  #?(:cljs (:require-macros [replicant.asserts])))
 
 (defmacro assert-no-class-name [headers]
   `(assert/assert

--- a/src/replicant/dom.cljs
+++ b/src/replicant/dom.cljs
@@ -3,7 +3,7 @@
             [replicant.protocols :as replicant]
             [replicant.transition :as transition]))
 
-(defn remove-listener [^js/HTMLElement el event]
+(defn remove-listener [^js/EventTarget el event]
   (when-let [old-handler (some-> el .-replicantHandlers (aget event))]
     (.removeEventListener el event old-handler)))
 
@@ -89,7 +89,7 @@
         (.removeAttribute el attr))
       this)
 
-    (set-event-handler [this ^js/HTMLElement el event handler]
+    (set-event-handler [this ^js/EventTarget el event handler]
       (when-not (.-replicantHandlers el)
         (set! (.-replicantHandlers el) #js {}))
       (let [event (name event)]
@@ -98,7 +98,7 @@
         (.addEventListener el event handler))
       this)
 
-    (remove-event-handler [this ^js/HTMLElement el event]
+    (remove-event-handler [this ^js/EventTarget el event]
       (let [event (name event)]
         (remove-listener el event)
         (aset (.-replicantHandlers el) event nil))

--- a/src/replicant/dom.cljs
+++ b/src/replicant/dom.cljs
@@ -3,7 +3,7 @@
             [replicant.protocols :as replicant]
             [replicant.transition :as transition]))
 
-(defn remove-listener [el event]
+(defn remove-listener [^js/HTMLElement el event]
   (when-let [old-handler (some-> el .-replicantHandlers (aget event))]
     (.removeEventListener el event old-handler)))
 
@@ -89,7 +89,7 @@
         (.removeAttribute el attr))
       this)
 
-    (set-event-handler [this el event handler]
+    (set-event-handler [this ^js/HTMLElement el event handler]
       (when-not (.-replicantHandlers el)
         (set! (.-replicantHandlers el) #js {}))
       (let [event (name event)]
@@ -98,7 +98,7 @@
         (.addEventListener el event handler))
       this)
 
-    (remove-event-handler [this el event]
+    (remove-event-handler [this ^js/HTMLElement el event]
       (let [event (name event)]
         (remove-listener el event)
         (aset (.-replicantHandlers el) event nil))


### PR DESCRIPTION
Please review - I noted issues using commit 2f682dcb451cffc913f8f5a91b63e4dfa1fecf43

1. errors because macros are not included in cljs compilations.
2. warnings requiring type hints.