### PR TITLE
Merge hiccup symbol attrs into unmounting attrs

### DIFF
--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -192,9 +192,8 @@
 
 (defn get-unmounting-attrs [vdom]
   (when (vdom/async-unmount? vdom)
-    (let [headers (get-hiccup-headers (vdom/sexp vdom) nil)
-          attrs (merge (get-attrs headers) (nth (vdom/sexp vdom) 1))
-          unmounting (:replicant/unmounting attrs)]
+    (let [attrs (vdom/attrs vdom)
+          unmounting (:replicant/unmounting (nth (vdom/sexp vdom) 1))]
       (prep-attrs (merge-attrs attrs unmounting) nil (vdom/classes vdom)))))
 
 (defn ^:private flatten-seqs* [xs coll]

--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -192,7 +192,8 @@
 
 (defn get-unmounting-attrs [vdom]
   (when (vdom/async-unmount? vdom)
-    (let [attrs (nth (vdom/sexp vdom) 1)
+    (let [headers (get-hiccup-headers (vdom/sexp vdom) nil)
+          attrs (merge (get-attrs headers) (nth (vdom/sexp vdom) 1))
           unmounting (:replicant/unmounting attrs)]
       (prep-attrs (merge-attrs attrs unmounting) nil (vdom/classes vdom)))))
 

--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -192,9 +192,9 @@
 
 (defn get-unmounting-attrs [vdom]
   (when (vdom/async-unmount? vdom)
-    (let [attrs (vdom/attrs vdom)
-          unmounting (:replicant/unmounting (nth (vdom/sexp vdom) 1))]
-      (prep-attrs (merge-attrs attrs unmounting) nil (vdom/classes vdom)))))
+    (-> (vdom/attrs vdom)
+        (merge-attrs (:replicant/unmounting (nth (vdom/sexp vdom) 1)))
+        (prep-attrs nil (vdom/classes vdom)))))
 
 (defn ^:private flatten-seqs* [xs coll]
   (reduce

--- a/test/replicant/core_test.clj
+++ b/test/replicant/core_test.clj
@@ -1229,6 +1229,33 @@
             [:add-class [:h1 "Title"] "unmounting"]
             [:on-transition-end [:h1 "Title"]]])))
 
+  (testing "Keeps id attribute from hiccup symbol while unmounting"
+    (is (= (-> (h/render [:div
+                          [:h1 "Title"]
+                          [:p#a {:class ["mounted"]
+                                 :replicant/unmounting {:class ["unmounting"]}}
+                           "Text"]])
+               (h/render [:div [:h1 "Title"]])
+               h/get-mutation-log-events
+               h/summarize)
+           [[:remove-class [:p#a "Text"] "mounted"]
+            [:add-class [:p#a "Text"] "unmounting"]
+            [:on-transition-end [:p#a "Text"]]])))
+
+  (testing "Keeps id from hiccup attribute map while unmounting"
+    (is (= (-> (h/render [:div
+                          [:h1 "Title"]
+                          [:p {:id "a"
+                               :class ["mounted"]
+                               :replicant/unmounting {:class ["unmounting"]}}
+                           "Text"]])
+               (h/render [:div [:h1 "Title"]])
+               h/get-mutation-log-events
+               h/summarize)
+           [[:remove-class [:p#a "Text"] "mounted"]
+            [:add-class [:p#a "Text"] "unmounting"]
+            [:on-transition-end [:p#a "Text"]]])))
+
   (testing "Unmounts asynchronously and updates nodes"
     (is (= (-> (h/render
                 [:article


### PR DESCRIPTION
To stop the unmounting transition from nuking the hiccup symbol id

* See #30

I couldn't figure out how to test the change to the `get-unmounting-attrs` function directly in any nice way, because I didn't see how to create a `vdom` from hiccup. Tested the change via the `unmounting-test` instead.

As I do not actually know what I am doing, the change could be totally bonkers of course. I do not understand the significance of `ns` when getting the `headers` for instance. Anyway, maybe I am going in the right direction, at least?