### PR TITLE
Fix hiccup symbol missing class

### DIFF
--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -57,7 +57,10 @@
 (defn parse-tag [^String tag]
   ;; Borrowed from hiccup, and adapted to support multiple classes
   (let [id-index (let [index (.indexOf tag "#")] (when (pos? index) index))
-        class-index (let [index (.indexOf tag ".")] (when (pos? index) index))
+        end-index (unchecked-dec-int (count tag))
+        class-index (let [index (.indexOf tag ".")] (when (and (pos? index)
+                                                               (not= end-index index)) 
+                                                      index))
         tag-name (cond
                    id-index (.substring tag 0 id-index)
                    class-index (.substring tag 0 class-index)

--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -56,11 +56,15 @@
 
 (defn parse-tag [^String tag]
   ;; Borrowed from hiccup, and adapted to support multiple classes
-  (let [id-index (let [index (.indexOf tag "#")] (when (pos? index) index))
-        end-index (unchecked-dec-int (count tag))
-        class-index (let [index (.indexOf tag ".")] (when (and (pos? index)
-                                                               (not= end-index index)) 
-                                                      index))
+  (let [end-index (unchecked-dec-int (count tag))
+        dot-index (let [index (.indexOf tag ".")] (when (pos? index) index))
+        class-index (when (and dot-index
+                               (not= end-index dot-index)) 
+                      dot-index)
+        id-index (let [index (.indexOf tag "#")] (when (and (pos? index)
+                                                            (not= end-index index)
+                                                            (not= dot-index (unchecked-inc-int index))) 
+                                                   index))
         tag-name (cond
                    id-index (.substring tag 0 id-index)
                    class-index (.substring tag 0 class-index)

--- a/test/replicant/core_test.clj
+++ b/test/replicant/core_test.clj
@@ -61,6 +61,30 @@
     (is (= (->> (sut/get-hiccup-headers [:div..] nil)
                 sut/get-attrs
                 :classes)
+           nil)))
+  
+  (testing "Finds id in hiccup symbol"
+    (is (= (->> (sut/get-hiccup-headers [:div#foo] nil)
+                sut/get-attrs
+                :id)
+           "foo")))
+  
+  (testing "Handles missing id in hiccup symbol"
+    (is (= (->> (sut/get-hiccup-headers [:div#] nil)
+                sut/get-attrs
+                :id)
+           nil)))
+  
+  (testing "Handles missing id in hiccup symbol, when there's a class"
+    (is (= (->> (sut/get-hiccup-headers [:div#.foo] nil)
+                sut/get-attrs
+                :id)
+           nil)))
+  
+  (testing "Handles missing id and class in hiccup symbol"
+    (is (= (->> (sut/get-hiccup-headers [:div#.] nil)
+                sut/get-attrs
+                :id)
            nil))))
 
 (deftest render-test

--- a/test/replicant/core_test.clj
+++ b/test/replicant/core_test.clj
@@ -31,7 +31,37 @@
                 :style
                 :z-index
                 (sut/get-style-val :z-index))
-           "999"))))
+           "999")))
+  
+  (testing "Finds classes in hiccup symbol"
+    (is (= (->> (sut/get-hiccup-headers [:div.foo.bar] nil)
+                sut/get-attrs
+                :classes)
+           ["foo" "bar"])))
+  
+  (testing "Handles missing class in hiccup symbol when there is a non-missing class"
+    (is (= (->> (sut/get-hiccup-headers [:div.foo.] nil)
+                sut/get-attrs
+                :classes)
+           ["foo"])))
+  
+  (testing "Handles several missing classes in hiccup symbol when there is a non-missing class"
+    (is (= (->> (sut/get-hiccup-headers [:div.foo..] nil)
+                sut/get-attrs
+                :classes)
+           ["foo"])))
+  
+  (testing "Handles missing class in hiccup symbol when there are no other classes"
+    (is (= (->> (sut/get-hiccup-headers [:div.] nil)
+                sut/get-attrs
+                :classes)
+           nil)))
+  
+  (testing "Handles several missing classes in hiccup symbol when there are no other classes"
+    (is (= (->> (sut/get-hiccup-headers [:div..] nil)
+                sut/get-attrs
+                :classes)
+           nil))))
 
 (deftest render-test
   (testing "Builds nodes"


### PR DESCRIPTION
Fixing:

* #33 

And also the similar situation for missing `id`.

I choose to first do this in `parse-tag`, since it seems “proper”. However, I am unsure about the performance implications of doing more checks there.

I see at least one other way to deal with it: let `parse-tag` produce a bit funny results and handle the cases when rendering. I haven't looked up how that would be done though, as I wanted to see what you say about the `parse-tag` path.