### PR TITLE
Fix issue with element attriutes of type number

### DIFF
--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -24,7 +24,8 @@
                                             (str/join " ")) "\"")
 
                        (str (name k)
-                            (when (and (string? v) (< 0 (count v)))
+                            (when (or (number? v)
+                                      (and (string? v) (< 0 (count v))))
                               (str "=\"" v "\"")))))))
            seq
            (str/join " ")

--- a/test/replicant/string_test.cljc
+++ b/test/replicant/string_test.cljc
@@ -34,6 +34,10 @@
     (is (= (sut/render [:h1 {:style {:border-width 2}} "Box"])
            "<h1 style=\"border-width: 2px;\">Box</h1>")))
 
+  (testing "Renders number attributes as stringified numbers"
+    (is (= (sut/render [:img {:height 10}])
+           "<img height=\"10\">")))
+  
   (testing "Renders arbitrary attributes"
     (is (= (sut/render [:h1 {:title "Color"} "Red"])
            "<h1 title=\"Color\">Red</h1>")))


### PR DESCRIPTION
This one I could fix in the string renderer. It stringifies any element attribute value of type number.