### PR TITLE
Fix string render issue with adding extra xmlns to svg element

### DIFF
--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -35,12 +35,14 @@
         newline (when (< 0 indent) "\n")]
     (if-let [text (hiccup/text headers)]
       (str indent-s text newline)
-      (let [tag-name (hiccup/tag-name headers)]
+      (let [tag-name (hiccup/tag-name headers)
+            attrs (r/get-attrs headers)]
         (str indent-s
              "<" tag-name
-             (when (= "svg" tag-name)
+             (when (and (= "svg" tag-name)
+                        (not (:xmlns attrs)))
                (str " xmlns=\"http://www.w3.org/2000/svg\""))
-             (render-attrs (r/get-attrs headers)) ">"
+             (render-attrs attrs) ">"
              newline
              (->> (r/get-children headers (hiccup/html-ns headers))
                   (keep #(some-> % (render-node {:depth (inc depth) :indent indent})))

--- a/test/replicant/string_test.cljc
+++ b/test/replicant/string_test.cljc
@@ -77,6 +77,11 @@
                 "<use xlink:href=\"#icon\"></use>"
                 "</g>"
                 "</svg>"))))
+  
+  (testing "Only generates one xmlns attribute for SVG node"
+    (is (= (sut/render
+            [:svg {:xmlns "http://www.w3.org/2000/svg"}])
+           "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>")))
 
   (testing "Ignores nil styles"
     (is (= (sut/render


### PR DESCRIPTION
If the svg hiccup already contains `:xmlns`, the generated string would contain two `xmlns=` attributes.

<img width="738" alt="image" src="https://github.com/user-attachments/assets/9ef35efc-3a2d-43ba-a9b8-77524225c357">
