### PR TITLE
Fix execution error in clojure

### DIFF
--- a/src/replicant/assert.cljc
+++ b/src/replicant/assert.cljc
@@ -1,5 +1,5 @@
 (ns replicant.assert
-  (:require [cljs.env :as env]
+  (:require #?(:cljs [cljs.env :as env])
             [replicant.console-logger :as console]
             [replicant.hiccup :as hiccup])
   (:refer-clojure :exclude [assert])
@@ -10,8 +10,10 @@
 (def error (atom nil))
 
 (defn assert? []
-  (if-let [options (and cljs.env/*compiler*
-                        (:options @cljs.env/*compiler*))]
+  (if-let [options #?(:cljs (and cljs.env/*compiler*
+                                 (:options @cljs.env/*compiler*))
+                      :clj (when (System/getProperty "replicant.asserts")
+                             {:replicant/asserts? true}))]
     (cond
       (contains? options :replicant/asserts?)
       (:replicant/asserts? options)


### PR DESCRIPTION
a simple program like

```
(ns my.ns
  (:require [replicant.string :as rs]))

(defn main [_]
  (println (rs/render [:h1 "hello"])))
```

crashes with

```
{:clojure.main/message
 "Execution error (FileNotFoundException) at
 replicant.assert/eval246$loading (assert.cljc:1).\nCould not locate
 cljs/env__init.class, cljs/env.clj or cljs/env.cljc on classpath.\n",
...
```

when clojurescript is not on the classpath.

this introduces a reader conditional to guard against this.

on jvm set the java property `replicant.asserts` to enable asserts