### PR TITLE
`replicant.string`: Escape HTML strings by default

### DIFF
--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -38,9 +38,9 @@
   https://github.com/weavejester/hiccup/blob/5a6d45c17728dcbcb3aeb32ea890fd9dc1508547/src/hiccup/util.clj#L80-L88"
   [text]
   (-> text
-      (str/replace "&"  "&amp;")
-      (str/replace "<"  "&lt;")
-      (str/replace ">"  "&gt;")
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")
       (str/replace "\"" "&quot;")
       (str/replace "'" "&apos;")))
 

--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -50,17 +50,15 @@
     (if-let [text (hiccup/text headers)]
       (str indent-s (apply str (map escape-html text)) newline)
       (let [tag-name (hiccup/tag-name headers)
-            attrs (r/get-attrs headers)
-            innerHTML (:innerHTML attrs)
-            rendered-attrs (render-attrs (dissoc attrs :innerHTML))]
+            attrs (r/get-attrs headers)]
         (str indent-s
              "<" tag-name
              (when (and (= "svg" tag-name)
                         (not (:xmlns attrs)))
                (str " xmlns=\"http://www.w3.org/2000/svg\""))
-             rendered-attrs ">"
+             (render-attrs (dissoc attrs :innerHTML)) ">"
              newline
-             (or innerHTML
+             (or (:innerHTML attrs)
                  (->> (r/get-children headers (hiccup/html-ns headers))
                       (keep #(some-> % (render-node {:depth (inc depth) :indent indent})))
                       str/join))

--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -51,8 +51,8 @@
       (str indent-s (apply str (map escape-html text)) newline)
       (let [tag-name (hiccup/tag-name headers)
             attrs (r/get-attrs headers)
-            innerHTML? (contains? attrs :innerHTML)
-            rendered-attrs (when-not innerHTML? (render-attrs attrs))]
+            innerHTML (:innerHTML attrs)
+            rendered-attrs (when-not innerHTML (render-attrs attrs))]
         (str indent-s
              "<" tag-name
              (when (and (= "svg" tag-name)
@@ -60,11 +60,10 @@
                (str " xmlns=\"http://www.w3.org/2000/svg\""))
              rendered-attrs ">"
              newline
-             (if innerHTML?
-               (:innerHTML attrs)
-               (->> (r/get-children headers (hiccup/html-ns headers))
-                    (keep #(some-> % (render-node {:depth (inc depth) :indent indent})))
-                    str/join))
+             (or innerHTML
+                 (->> (r/get-children headers (hiccup/html-ns headers))
+                      (keep #(some-> % (render-node {:depth (inc depth) :indent indent})))
+                      str/join))
              (when-not (self-closing? tag-name)
                (str indent-s "</" tag-name ">" newline)))))))
 

--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -52,7 +52,7 @@
       (let [tag-name (hiccup/tag-name headers)
             attrs (r/get-attrs headers)
             innerHTML (:innerHTML attrs)
-            rendered-attrs (when-not innerHTML (render-attrs attrs))]
+            rendered-attrs (render-attrs (dissoc attrs :innerHTML))]
         (str indent-s
              "<" tag-name
              (when (and (= "svg" tag-name)

--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -31,25 +31,40 @@
            (str/join " ")
            (str " ")))
 
+(defn escape-html
+  "Change special characters into HTML character entities.
+
+  Taken from Hiccup:
+  https://github.com/weavejester/hiccup/blob/5a6d45c17728dcbcb3aeb32ea890fd9dc1508547/src/hiccup/util.clj#L80-L88"
+  [text]
+  (-> text
+      (str/replace "&"  "&amp;")
+      (str/replace "<"  "&lt;")
+      (str/replace ">"  "&gt;")
+      (str/replace "\"" "&quot;")
+      (str/replace "'" "&apos;")))
+
 (defn render-node [headers & [{:keys [depth indent]}]]
   (let [indent-s (when (< 0 indent) (str/join (repeat (* depth indent) " ")))
         newline (when (< 0 indent) "\n")]
     (if-let [text (hiccup/text headers)]
-      (str indent-s text newline)
+      (str indent-s (apply str (map escape-html text)) newline)
       (let [tag-name (hiccup/tag-name headers)
             attrs (r/get-attrs headers)]
-        (str indent-s
-             "<" tag-name
-             (when (and (= "svg" tag-name)
-                        (not (:xmlns attrs)))
-               (str " xmlns=\"http://www.w3.org/2000/svg\""))
-             (render-attrs attrs) ">"
-             newline
-             (->> (r/get-children headers (hiccup/html-ns headers))
-                  (keep #(some-> % (render-node {:depth (inc depth) :indent indent})))
-                  str/join)
-             (when-not (self-closing? tag-name)
-               (str indent-s "</" tag-name ">" newline)))))))
+        (if (= :replicant/raw-string (some-> headers hiccup/sexp first))
+          (apply str indent-s (hiccup/children headers))
+          (str indent-s
+               "<" tag-name
+               (when (and (= "svg" tag-name)
+                          (not (:xmlns attrs)))
+                 (str " xmlns=\"http://www.w3.org/2000/svg\""))
+               (render-attrs attrs) ">"
+               newline
+               (->> (r/get-children headers (hiccup/html-ns headers))
+                    (keep #(some-> % (render-node {:depth (inc depth) :indent indent})))
+                    str/join)
+               (when-not (self-closing? tag-name)
+                 (str indent-s "</" tag-name ">" newline))))))))
 
 (defn render [hiccup & [{:keys [indent]}]]
   (if hiccup

--- a/test/replicant/string_test.cljc
+++ b/test/replicant/string_test.cljc
@@ -132,7 +132,15 @@
     (is (= (sut/render
             [:div {:innerHTML "<script>alert(\"boom\")</script>"}
              "Children should be ignored when :innerHTML is set."])
-           "<div><script>alert(\"boom\")</script></div>"))))
+           "<div><script>alert(\"boom\")</script></div>")))
+
+  (testing ":innerHTML can be used together with other attributes"
+    (is (= (sut/render
+            [:div (sorted-map :innerHTML "<script>alert(\"boom\")</script>"
+                              :class "contains-script"
+                              :id "the-script-container")
+             "Children should be ignored when :innerHTML is set."])
+           "<div class=\"contains-script\" id=\"the-script-container\"><script>alert(\"boom\")</script></div>"))))
 
 (deftest escape-html-test
   (is (= (sut/escape-html "<script>alert(\"boom\")</script>")

--- a/test/replicant/string_test.cljc
+++ b/test/replicant/string_test.cljc
@@ -121,4 +121,18 @@
   (testing "Skips nil children"
     (is (= (sut/render
             [:div nil [:div "Ok"]])
-           "<div><div>Ok</div></div>"))))
+           "<div><div>Ok</div></div>")))
+
+  (testing "Escapes HTML"
+    (is (= (sut/render
+            [:div "<script>alert(\"boom\")</script>"])
+           "<div>&lt;script&gt;alert(&quot;boom&quot;)&lt;/script&gt;</div>")))
+
+  (testing "Passes through raw strings"
+    (is (= (sut/render
+            [:replicant/raw-string "<script>alert(\"boom\")</script>"])
+           "<script>alert(\"boom\")</script>"))))
+
+(deftest escape-html-test
+  (is (= (sut/escape-html "<script>alert(\"boom\")</script>")
+         "&lt;script&gt;alert(&quot;boom&quot;)&lt;/script&gt;")))

--- a/test/replicant/string_test.cljc
+++ b/test/replicant/string_test.cljc
@@ -130,8 +130,9 @@
 
   (testing "Passes through raw strings"
     (is (= (sut/render
-            [:replicant/raw-string "<script>alert(\"boom\")</script>"])
-           "<script>alert(\"boom\")</script>"))))
+            [:div {:innerHTML "<script>alert(\"boom\")</script>"}
+             "Children should be ignored when :innerHTML is set."])
+           "<div><script>alert(\"boom\")</script></div>"))))
 
 (deftest escape-html-test
   (is (= (sut/escape-html "<script>alert(\"boom\")</script>")


### PR DESCRIPTION
Hi!

Attached is a stab at #42.

## Prior work: Hiccup

Hiccup uses a custom type for marking something as an "OK string to pass through".
This means the user opts in to use raw strings, and normal strings are escaped.

```
(deftype RawString [^String s]
  Object
  (^String toString [this] s)
  (^boolean equals [this other]
    (and (instance? RawString other)
         (= s  (.toString other)))))
         
;; Source: https://github.com/weavejester/hiccup/blob/5a6d45c17728dcbcb3aeb32ea890fd9dc1508547/src/hiccup/util.clj#L60-L65
```

## Description

Strings are escaped by default:

```clojure
(replicant.string/render [:div "<script>alert(\"boom\")</script>"])
;; => "<div>&lt;script&gt;alert(&quot;boom&quot;)&lt;/script&gt;</div>"
```

but `:replicant/raw-string` is an escape hatch:

```clojure
(replicant.string/render [:replicant/raw-string "<script>alert(\"boom\")</script>"])
;; => "<script>alert(\"boom\")</script>"
```

## What about `replicant.dom`?

I'm not quite sure. I started with a rendering to string, I think a similar approach might work for DOM rendering.

## This PR may degrade `replicant.string/render-node` performance

I've added an additional `if` that checks if the we're currently rendering a raw string on _every element render_. There may be faster alternatives.

## Discussion

I like using `:replicant/raw-string` to opt out of string escaping:

```clojure
(replicant.string/render [:replicant/raw-string "<script>alert(\"boom\")</script>"])
;; => "<script>alert(\"boom\")</script>"
```

... but I don't like that I'm introducing nesting into `replicant.string/render-node`.