### PR TITLE
Bugfix: `set-event-handler` expects a function and not the event-handler as data.

### DIFF
--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -415,7 +415,7 @@
                  (when (and new-handler (not= new-handler old-handler))
                    (if-let [handler (get new-handler :replicant.event/handler)]
                      (r/set-event-handler renderer el k handler new-opts)
-                     (r/set-event-handler renderer el k new-handler nil))))))))
+                     (r/set-event-handler renderer el k (get-event-handler new-handler nil) nil))))))))
 
 (def xlinkns "http://www.w3.org/1999/xlink")
 (def xmlns "http://www.w3.org/XML/1998/namespace")


### PR DESCRIPTION
For context here a tiny part of the [discussion](https://clojurians.slack.com/archives/C06JZ4X334N/p1740555565637609?thread_ts=1740497449.144609&cid=C06JZ4X334N) from the clojurians #replicant Slack channel:

> I was able to reproduce the issue in a smaller example.
All three examples work fine:
[Basic drag](https://github.com/maxweber/replicant-drag-example/commit/3296662bde05aa15671cf9844fa65886b5d9d054)
[Dragging multiple clips](https://github.com/maxweber/replicant-drag-example/commit/d6bbabc8cc0910b4add30962717943c304b1503d)
[Dragging multiple clips where the data is managed in DataScript](https://github.com/maxweber/replicant-drag-example/commit/0043d32d6bb382df92d8bc7c2b41c6500eb29552)
However, all examples uses an old Replicant version (that is used in the [Replicant mini example](https://github.com/anteoas/replicant-mini-app)). When I switch them to the newest [Replicant version](https://github.com/cjohansen/replicant/commit/156c3990f609e60c4ca87500002a247c1c7cf5f7) only the last example that uses DataScript breaks:
https://github.com/maxweber/replicant-drag-example/commit/5b7d8bf1a26e67275dfc71b532c3cef33c8c158f

The variant with the regression looks like this:

![image](https://github.com/user-attachments/assets/49d38fe1-4f48-415f-a28e-56c1e3cadb7c)

Here it was only possible to drag each div once. Afterwards the mousedown event listener on the corresponding div was gone due to the issue that is fixed by this PR.

A variant of the example with the fix of this PR can be found here:

https://github.com/maxweber/replicant-drag-example/commit/de79c25664a1a8a39c6c1854d84dd31f92e6f86f

I'm unsure if it is fine to pass `nil` as the second argument (event) to `get-event-handler` in this case?