### PR TITLE
reconcile* foreignObject leaks svg namespace to children

### DIFF
--- a/src/replicant/core.cljc
+++ b/src/replicant/core.cljc
@@ -121,7 +121,7 @@
                                 (keyword? class) (name class)
                                 (symbol? class) (name class)
                                 (string? class) (not-empty (.trim ^String class)))))
-                         classes)
+                          classes)
     (string? classes) (keep #(not-empty (.trim ^String %)) (.split ^String classes " "))
     :else (throw (ex-info "class name is neither string, keyword, or a collection of those"
                           {:classes classes}))))
@@ -673,9 +673,10 @@
       :else (recur (unchecked-inc-int coll-n) (unchecked-inc-int dom-n) (next xs)))))
 
 (defn get-ns [headers]
-  (or (hiccup/html-ns headers)
-      (when (= "svg" (hiccup/tag-name headers))
-        "http://www.w3.org/2000/svg")))
+  (when-not (= "foreignObject" (hiccup/tag-name headers))
+    (or (hiccup/html-ns headers)
+        (when (= "svg" (hiccup/tag-name headers))
+          "http://www.w3.org/2000/svg"))))
 
 (defn ^:private insert-children [{:keys [renderer] :as impl} el children vdom]
   (reduce (fn [[res n] child]

--- a/test/replicant/core_test.cljc
+++ b/test/replicant/core_test.cljc
@@ -334,6 +334,17 @@
                (nth 2))
            [:create-element "div"])))
 
+  (testing "Does not force SVG namespace on foreignObject children added during reconcile"
+    (is (= (->> (-> (h/render [:svg [:foreignObject
+                                     [:div {:replicant/key :a} "A"]]])
+                    (h/render [:svg [:foreignObject
+                                     [:div {:replicant/key :a} "A"]
+                                     [:div {:replicant/key :b} "B"]]])
+                    h/get-mutation-log-events
+                    h/summarize)
+                (filter (comp #{:create-element} first)))
+           [[:create-element "div"]])))
+
   (testing "Re-creates unkeyed moved nodes"
     (is (= (-> (h/render [:div
                           [:h1 {} "Title"]
@@ -823,7 +834,7 @@
                h/summarize)
            [[:set-event-handler [:h1 "Hi!"] :click f1 {"capture" true}]])))
 
-    (testing "Ignores nil event handler"
+  (testing "Ignores nil event handler"
     (is (= (-> (h/render [:h1 "Hi!"])
                (h/render [:h1 {:on {:click nil}} "Hi!"])
                h/get-mutation-log-events
@@ -2535,8 +2546,7 @@
                  [:div {:replicant/key "A"} "A"]
                  [:div {:replicant/key "B2"} "B2"]
                  [:div {:replicant/key "C"} "C"]
-                 [:div {:replicant/key "D2"} "D2"]
-                 ])
+                 [:div {:replicant/key "D2"} "D2"]])
                h/get-mutation-log-events
                h/summarize)
            [[:create-element "div"]


### PR DESCRIPTION
Hi,

I've been working on data modelling frontend and I've experienced problem with Replicant. 

Entity is represented as foreignObject and contains attributes (HTML). What happens is that on first render entity looks OK. When I add attribute  the foreignObject attaches DOM node properly, but browser doesn't reflect/render it.

I've pinpointed cause  to `get-ns` function that is used during reconciliation. It leaks `svg` namespace from foreignObject parent to created/appended children during `reconcile*`.

Bottom line is that `create-node` does respect foreignObject children no namespace, but`reconcile*` does not.

This PR should fix it. Hope that it aligns with your coding practices....