### PR TITLE
Escape top-level strings in the String renderer, and fix the double quote escaping typo

### DIFF
--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -50,7 +50,7 @@
       (str/replace "&" "&amp;")
       (str/replace "<" "&lt;")
       (str/replace ">" "&gt;")
-      (str/replace "\"" "&#39;")
+      (str/replace "\"" "&#34;")
       (str/replace "'" "&apos;")))
 
 (defn ^:no-doc render-attrs [stringifier attrs]

--- a/src/replicant/string.cljc
+++ b/src/replicant/string.cljc
@@ -174,4 +174,4 @@
           (render-node stringifier (r/get-hiccup-headers nil hiccup-node) opt))
         (to-string stringifier))
 
-      :else (str hiccup))))
+      :else (escape-html (str hiccup)))))

--- a/test/replicant/string_test.cljc
+++ b/test/replicant/string_test.cljc
@@ -68,7 +68,7 @@
 
   (testing "Escapes attribute values"
     (is (= (sut/render [:h1 {:title "{\"foo\": \"bar\"}"} "Red"])
-           "<h1 title=\"{&#39;foo&#39;: &#39;bar&#39;}\">Red</h1>")))
+           "<h1 title=\"{&#34;foo&#34;: &#34;bar&#34;}\">Red</h1>")))
 
   (testing "Escapes style values"
     (is (= (sut/render [:h1 {:style {:color "<xss>"}} "Hello"])
@@ -192,7 +192,7 @@
   (testing "Escapes HTML"
     (is (= (sut/render
             [:div "<script>alert(\"boom\")</script>"])
-           "<div>&lt;script&gt;alert(&#39;boom&#39;)&lt;/script&gt;</div>")))
+           "<div>&lt;script&gt;alert(&#34;boom&#34;)&lt;/script&gt;</div>")))
 
   (testing "Passes through raw strings"
     (is (= (sut/render
@@ -285,4 +285,4 @@
 
 (deftest escape-html-test
   (is (= (sut/escape-html "<script>alert(\"boom\")</script>")
-         "&lt;script&gt;alert(&#39;boom&#39;)&lt;/script&gt;")))
+         "&lt;script&gt;alert(&#34;boom&#34;)&lt;/script&gt;")))

--- a/test/replicant/string_test.cljc
+++ b/test/replicant/string_test.cljc
@@ -61,7 +61,7 @@
   (testing "Renders number attributes as stringified numbers"
     (is (= (sut/render [:img {:height 10}])
            "<img height=\"10\">")))
-  
+
   (testing "Renders arbitrary attributes"
     (is (= (sut/render [:h1 {:title "Color"} "Red"])
            "<h1 title=\"Color\">Red</h1>")))
@@ -117,7 +117,7 @@
                 "<use xlink:href=\"#icon\"></use>"
                 "</g>"
                 "</svg>"))))
-  
+
   (testing "Only generates one xmlns attribute for SVG node"
     (is (= (sut/render
             [:svg {:xmlns "http://www.w3.org/2000/svg"}])
@@ -281,7 +281,16 @@
 
   (testing "Renders lazy seqs"
     (is (= (sut/render (lazy-seq '([:h1 "Hello"])))
-           "<h1>Hello</h1>"))))
+           "<h1>Hello</h1>")))
+
+  (testing "Escapes top-level strings"
+    (is (= (sut/render "<script defer>alert('oops xss')</script>")
+           (sut/render (list "<script defer>" "alert('oops xss')" "</script>"))
+           ;; TODO: Requires #79 to be resolved
+           #_(sut/render (lazy-seq (list "<script defer>" (list "alert('oops xss')" "</script>"))))
+           "&lt;script defer&gt;alert(&apos;oops xss&apos;)&lt;/script&gt;"))
+    (is (= (sut/render (list \< "br" \/ \>))
+           "&lt;br/&gt;"))))
 
 (deftest escape-html-test
   (is (= (sut/escape-html "<script>alert(\"boom\")</script>")


### PR DESCRIPTION
(See #78 for issue details)

Decided to do one pull request, but keep the commits separate just in case.